### PR TITLE
Update Chronyd exec behaviour to be consistent between first and subsequent boots

### DIFF
--- a/pkg/vorteil/ntp.go
+++ b/pkg/vorteil/ntp.go
@@ -56,7 +56,7 @@ func setupChronyD(ntps []string) error {
 
 		logDebug("ntp config:\n %s", chronydCfgData)
 
-		startChrony()
+		return startChrony()
 	}
 
 	return nil

--- a/pkg/vorteil/ntp.go
+++ b/pkg/vorteil/ntp.go
@@ -24,7 +24,7 @@ rtcsync`
 	chronydCfgPath = "/etc/chrony.conf"
 )
 
-func setupChronyD(ntps []string) error {
+func setupChronyD(ntps []string) (*exec.Cmd, error) {
 
 	logDebug("ntp servers found: %d", len(ntps))
 
@@ -40,7 +40,7 @@ func setupChronyD(ntps []string) error {
 		logAlways("ntp servers\t: %s", strings.Join(ntps, ", "))
 		if _, err := os.Stat(filepath.Dir(chronydCfgPath)); os.IsNotExist(err) {
 			if err := os.MkdirAll(filepath.Dir(chronydCfgPath), 0755); err != nil {
-				return fmt.Errorf("could not create directory: %v", err)
+				return nil, fmt.Errorf("could not create directory: %v", err)
 			}
 		}
 
@@ -51,7 +51,7 @@ func setupChronyD(ntps []string) error {
 
 		// Write config data
 		if err := ioutil.WriteFile(chronydCfgPath, []byte(chronydCfgData), 0644); err != nil {
-			return fmt.Errorf("could not write config file: %v", err)
+			return nil, fmt.Errorf("could not write config file: %v", err)
 		}
 
 		logDebug("ntp config:\n %s", chronydCfgData)
@@ -59,16 +59,16 @@ func setupChronyD(ntps []string) error {
 		return startChrony()
 	}
 
-	return nil
+	return nil, nil
 }
 
-func startChrony() error {
+func startChrony() (*exec.Cmd, error) {
 	// Start ChronyD
-	chronydCMD := exec.Command("/vorteil/chronyd") // set args to []string{"-l", "/etc/chrony.log"}... to save logs
-	chronydCMD.SysProcAttr = &syscall.SysProcAttr{
+	chronydCmd := exec.Command("/vorteil/chronyd") // set args to []string{"-l", "/etc/chrony.log"}... to save logs
+	chronydCmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{Uid: uint32(rootID), Gid: uint32(rootID)},
 	}
 
-	return chronydCMD.Start()
+	return chronydCmd, chronydCmd.Start()
 
 }

--- a/pkg/vorteil/vinitd.go
+++ b/pkg/vorteil/vinitd.go
@@ -479,10 +479,13 @@ func (v *Vinitd) PostSetup() error {
 
 	// Setup ChronyD NTP Server
 	go func() {
-		if err := setupChronyD(v.vcfg.System.NTP); err != nil {
+		defer wg.Done()
+		chronydCmd, err := setupChronyD(v.vcfg.System.NTP)
+		if err != nil {
 			errors <- err
+			return
 		}
-		wg.Done()
+		logDebug("chronyd started successfully with pid %d", chronydCmd.Process.Pid)
 	}()
 
 	// wait on all tasks


### PR DESCRIPTION
## Description

Partially addresses #9. Propagate result of starting `chronyd` in both the case where `/etc/chrony.conf` exists and when it doesn't. Also debug log the PID to track the success case.

## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Adding the return statement for the config-exists `startChrony()` call caused VMs that can't boot chronyd to crash even on first boot (i.e. not just on second boot as per #9).

For VMs that can boot chronyd, I've confirmed in a test that PID is now successfully logged to the VM console on boot when in debug.

## Test Platform Details (if applicable)

**Operating system:** Proxmox VE

**Hypervisors/Platforms (if applicable):** qemu/KVM
